### PR TITLE
RSP-2802: Fail CI Build When Sonar Cloud Quality Gate Fails

### DIFF
--- a/steps/codeanalysis/cli_prepare_analysis_configuration.yaml
+++ b/steps/codeanalysis/cli_prepare_analysis_configuration.yaml
@@ -11,3 +11,5 @@ steps:
       configMode: 'manual'
       cliProjectKey: ${{ parameters.project_key }}
       cliProjectName: ${{ parameters.project_name }}
+      extraProperties: |
+        sonar.scanner.metadataFilePath=$(Agent.TempDirectory)/sonar/$(Build.BuildNumber)/test/report-task.txt

--- a/steps/codeanalysis/prepare_analysis_configuration.yaml
+++ b/steps/codeanalysis/prepare_analysis_configuration.yaml
@@ -14,6 +14,7 @@ steps:
       extraProperties: |
         sonar.cs.opencover.reportsPaths=$(Build.SourcesDirectory)/**/coverage.opencover.xml
         sonar.cs.xunit.reportsPaths=$(Build.SourcesDirectory)/**/test_results.xml
+        sonar.scanner.metadataFilePath=$(Agent.TempDirectory)/sonar/$(Build.BuildNumber)/test/report-task.txt
 
   - task: Cache@2
     displayName: Cache SonarScanner

--- a/steps/codeanalysis/publish_quality_gate_result.yaml
+++ b/steps/codeanalysis/publish_quality_gate_result.yaml
@@ -2,3 +2,9 @@ steps:
   - task: SonarCloudPublish@3
     inputs:
       pollingTimeoutSec: '300'
+
+  - task: sonarcloud-buildbreaker@2
+    displayName: 'Quality Gate Validation'
+    inputs:
+      SonarCloud: 'Sonar Cloud GitHub'
+      Organization: 'healthresearchauthority'


### PR DESCRIPTION
## What was the purpose of this ticket?

To fail the build when Sonar Cloud Quality Gate fails

## Jira Ref

Replace the `###` with the Jira Ticket number below

[RSP-2802](https://nihr.atlassian.net/browse/RSP-2802)

## Type of Change

Put [X] inside the [] to make the box ticked

- [X] New feature
- [ ] Refactoring
- [ ] Bug-fix
- [X] DevOps
- [ ] Testing

## Solution

What work was completed to cover off the story?

- Added Sonar Cloud Build Breaker task to break the build if Quality Gate fails.